### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.DS_Store


### PR DESCRIPTION
MacOS adds a `.DS_Store` on every folder. We should ignore it.